### PR TITLE
Merge Release 27.2 to master now live 

### DIFF
--- a/DFC.Api.AppRegistry.UnitTests/DFC.Api.AppRegistry.UnitTests.csproj
+++ b/DFC.Api.AppRegistry.UnitTests/DFC.Api.AppRegistry.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <ProjectGuid>{471E5567-3F89-4F41-BC17-98FA00091150}</ProjectGuid>
     <CodeAnalysisRuleSet>../UnitTests.CodeAnalysis.ruleset</CodeAnalysisRuleSet>
@@ -13,9 +13,9 @@
 
   <ItemGroup>
     <PackageReference Include="DFC.Compui.Subscriptions" Version="1.0.67" />
-    <PackageReference Include="FakeItEasy" Version="6.2.1" />
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
+    <PackageReference Include="FakeItEasy" Version="7.3.1" />
+    <PackageReference Include="FluentAssertions" Version="6.9.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -23,9 +23,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/DFC.Api.AppRegistry/DFC.Api.AppRegistry.csproj
+++ b/DFC.Api.AppRegistry/DFC.Api.AppRegistry.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <CodeAnalysisRuleSet>../DFC.Digital.CodeAnalysis.ruleset</CodeAnalysisRuleSet>
-    <ProjectGuid>{E5160D3E-46F2-4384-8C57-078251EB776E}</ProjectGuid>
+	  <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
+	  <ProjectGuid>{E5160D3E-46F2-4384-8C57-078251EB776E}</ProjectGuid>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
@@ -12,25 +13,25 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Messaging.EventGrid" Version="4.13.0" />
     <PackageReference Include="AzureFunctions.Extensions.Swashbuckle" Version="1.4.5-preview5" />
     <PackageReference Include="DFC.Compui.Cosmos" Version="1.0.67" />
     <PackageReference Include="DFC.Compui.Subscriptions" Version="1.0.67" />
-    <PackageReference Include="DFC.Swagger.Standard" Version="0.1.20" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.25" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.15.0" />
-    <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="3.1.9" />
-    <PackageReference Include="Microsoft.Azure.EventGrid" Version="3.2.0" />
+    <PackageReference Include="DFC.Swagger.Standard" Version="0.1.27" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
+    <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="7.0.2" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.CosmosDB" Version="3.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.9" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="3.1.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.9" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.9" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.9" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.CosmosDB" Version="4.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.3" />
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
@@ -43,10 +44,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="local.settings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
-    </None>
-    <None Update="local.settings-template.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>

--- a/DFC.Api.AppRegistry/Models/AppRegistrationModel.cs
+++ b/DFC.Api.AppRegistry/Models/AppRegistrationModel.cs
@@ -97,6 +97,9 @@ namespace DFC.Api.AppRegistry.Models
         [Display(Description = "List of CSS Scripts required by the application.")]
         public Dictionary<string, string?>? CssScriptNames { get; set; }
 
+        [Display(Description = "Indicator stating that the application is interactive")]
+        public bool IsInteractiveApp { get; set; }
+
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
             var result = new List<ValidationResult>();

--- a/README.md
+++ b/README.md
@@ -2,4 +2,75 @@
 
 ## Introduction
 
-An introduction to the project goes here!
+This function app is used to manage CUI app registrations consumed by the Composite Shell, which are persisted in a Cosmos database collection.
+
+## Getting Started
+
+This is a self-contained Visual Studio 2019 solution containing a number of projects (azure function app with associated unit test project).
+
+### Installing
+
+Clone the project and open the solution in Visual Studio 2019.
+
+## List of dependencies
+
+|Item|Purpose|
+|----|-------|
+|DFC.Compui.Cosmos|Cosmos repository nuget|
+|DFC.Compui.Subscriptions|Composite UI Subscription API client|
+|DFC.Swagger.Standard|DFC Swagger generator|
+
+
+## Local Config Files
+
+Once you have cloned the public repo you need to remove the -template part from the configuration file names listed below.
+
+|Location|Filename|Rename to|
+|--------|--------|---------|
+|DFC.Api.AppRegistry|local.settings-template.json|local.settings.json|
+
+## Configuring to run locally
+
+The project contains a "local.settings-template.json" file which contains appsettings for the function app project. To use this file, copy it to "local.settings.json" and edit and replace the configuration item values with values suitable for your environment.
+
+By default, the appsettings include local Azure Cosmos Emulator configurations using the well known configuration values for app registration storage. These may be changed to suit your environment if you are not using the Azure Cosmos Emulator.
+
+This app subscribes to change events in Event Grid. To make use of it you will need to configure the Subscriptions service which will require an APIM API key for that service.
+
+## App Settings
+
+|App setting|Value|
+|-----------|-----|
+|ApiSuffix|dev|
+|Configuration__CosmosDbConnections__AppRegistry__AccessKey|__CosmosAccessKey__|
+|Configuration__CosmosDbConnections__AppRegistry__EndpointUrl|__CosmosEndpoint__|
+|Configuration__CosmosDbConnections__AppRegistry__DatabaseId|composition|
+|Configuration__CosmosDbConnections__AppRegistry__CollectionId|appregistry|
+|Configuration__CosmosDbConnections__AppRegistry__PartitionKey|/PartitionKey|
+|PagesClientOptions__BaseAddress|__ContentApiEndpoint__/api/execute/|
+|SubscriptionSettings__Endpoint|__ThisFunctionAppBaseAddress__/pages/webhook|
+|SubscriptionSettings__SubscriptionServiceEndpoint|__SubscriptionServiceEndpoint__|
+|SubscriptionSettings__ApiKey|__SubscriptionServiceApimKey__|
+|SubscriptionSettings__Filter__BeginsWith|/dfc-app-pages/|
+|SubscriptionSettings__Filter__IncludeEventTypes__0|published|
+|SubscriptionSettings__Filter__IncludeEventTypes__1|unpublished|
+|SubscriptionSettings__Filter__IncludeEventTypes__2|deleted|
+
+## Running locally
+
+To run this product locally, you will need to configure the list of dependencies, once configured and the configuration files updated, it should be F5 to run and debug locally.
+
+To run the project, start the function app. Once running, use a tool such as Postman to initiate requests.
+
+## Deployments
+
+This function app will be deployed as an individual stand-alone deployment.
+
+## Built With
+
+* Microsoft Visual Studio 2019
+* .Net Core 3.1
+
+## References
+
+Please refer to https://github.com/SkillsFundingAgency/dfc-digital for additional instructions on configuring individual components like Cosmos.

--- a/Resources/ArmTemplates/template.json
+++ b/Resources/ArmTemplates/template.json
@@ -217,7 +217,7 @@
             "value": [
               {
                 "name": "FUNCTIONS_EXTENSION_VERSION",
-                "value": "~3"
+                "value": "~4"
               },
               {
                 "name": "FUNCTIONS_WORKER_RUNTIME",

--- a/Resources/AzureDevOps/azure-pipelines.yml
+++ b/Resources/AzureDevOps/azure-pipelines.yml
@@ -48,6 +48,5 @@ stages:
          SolutionBaseName: $(SolutionBaseName)
          BuildPlatform: $(BuildPlatform)
          BuildConfiguration: $(BuildConfiguration)
-         DotNetCoreVersion: '3.1.100'
          PublishWebApp: true
          TestSuffix: UnitTests


### PR DESCRIPTION
* Added retries for 429 errors

* Removed code for legacy paths and regions

* Removed unused methods from LegacyDataLoadService

* Removed unused interfaces

* Tidy up of tests for removed code

* Removed AutoMapper

* Naming tidy up

* Removed unused settings from template file

* Remove code smell

* Added new enum value

* Remove app settings

* Updated readme.md file

* added is interactive flag

* upgrading to .NET6

Upgrading NuGet packages; latest DFC.Compui.Subscriptions has webhook classes removed so cannot be upgraded; latest Microsoft.Extensions.* doesn't work so 3.1.32 must be used

* Updated msbuild tools

* Downgrade of versions due to dependency issue

* fix for "Could not load file or assembly..." runtime error

---------